### PR TITLE
Added PR branch check workflow

### DIFF
--- a/.github/workflows/branch-check.yaml
+++ b/.github/workflows/branch-check.yaml
@@ -1,0 +1,14 @@
+name: PR Branch Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if PR is from develop branch
+        if: github.base_ref == 'main' && github.head_ref != 'develop'
+        run: exit 1

--- a/.github/workflows/branch-check.yaml
+++ b/.github/workflows/branch-check.yaml
@@ -2,8 +2,6 @@ name: PR Branch Check
 
 on:
   pull_request:
-    branches:
-      - main
 
 jobs:
   check-branch:

--- a/.github/workflows/branch-check.yaml
+++ b/.github/workflows/branch-check.yaml
@@ -11,4 +11,6 @@ jobs:
     steps:
       - name: Check if PR is from develop branch
         if: github.base_ref == 'main' && github.head_ref != 'develop'
-        run: exit 1
+        run: |
+          echo "Please select develop branch as the base branch for this PR"
+          exit 1


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to ensure that pull requests are made from the `develop` branch to the `main` branch. This helps maintain the workflow and prevents direct changes to the `main` branch.

Key change:

* [`.github/workflows/branch-check.yaml`](diffhunk://#diff-4ccc8164ab2fe262adbd238124f40624f6e241f2b17b5ae442c2a19705020345R1-R16): Added a new workflow named "PR Branch Check" that triggers on pull requests to the `main` branch. It checks if the pull request is from the `develop` branch and fails if it is not.